### PR TITLE
Add .htaccess to enable HTTPS redirects and client-side routing

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,4 @@
+Options -MultiViews
 RewriteEngine on
 
 # Redirect to HTTPS
@@ -7,7 +8,5 @@ RewriteRule ^(.*)$ https://www.megp19.com/$1 [L,NC,R=301]
 
 # Don't rewrite files or directories
 RewriteCond %{REQUEST_FILENAME} -f [OR]
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^ - [L]
 # Rewrite everything else to index.html to allow html5 state links
-RewriteRule ^ index.html [L]
+RewriteRule ^ index.html [QSA,L]


### PR DESCRIPTION
This is important because currently travelling to [megp19.com](megp19.com) does not automatically upgrade you to HTTPS, and, more importantly, [https://www.megp19.com/employment](https://www.megp19.com/employment) just _doesn't work._

The redirect rules were taken from fitzball (HTTPS) and previous react apps (client-side routing)