### PR TITLE
Add automatic time switch to ticketing

### DIFF
--- a/src/page/TicketPage.tsx
+++ b/src/page/TicketPage.tsx
@@ -16,11 +16,16 @@ export default class TicketPage extends React.Component{
   }
 
   public render(){
-    return (
-      <Page name="tickets" title="Tickets">
-          Tickets will be released at 12 noon on Sunday!
-      </Page>
-    );
+    const time = Date.now()
+
+    if(time < 1550354400*1000){ // Before 16th Feb at 22:00
+      return (
+        <Page name="tickets" title="Tickets">
+            Tickets will be released at 12 noon on Sunday!
+        </Page>
+      );
+    }
+
     return ( 
       <Page name="tickets">
         {


### PR DESCRIPTION
Given that we're not around at 10pm on Saturday, this change automatically shows the ticketing widget if their system clock is after a certain time. It's not security critical that the correct thing is shown, so no server-side time is required.

Tested with `Date.now = () => 1550354400*1000 + 1` and triggering a re-render by clicking a nav-link.